### PR TITLE
Improve/add support for multiple safety controllers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 project(ra-utils
-    VERSION 0.11.0
+    VERSION 0.12.0
     DESCRIPTION "Command line tools related to the Renesas MCU (aka safety controller)"
     LANGUAGES C
 )

--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -9,8 +9,17 @@ install(
 
 install(
     FILES
-        ra-update.service
+        ra-update@.service
     DESTINATION /lib/systemd/system
+)
+
+install(
+    DIRECTORY
+        ra-update@ttyLP1.service.d
+        ra-update@ttyLP2.service.d
+    DESTINATION /lib/systemd/system
+    FILES_MATCHING
+    PATTERN "*.conf"
 )
 
 install(

--- a/firmware/ra-update@.service
+++ b/firmware/ra-update@.service
@@ -5,6 +5,7 @@ RequiresMountsFor=/var/log
 
 [Service]
 Type=oneshot
+Environment="SAFETY_MCU_UART=/dev/%i"
 ExecStart=/usr/libexec/ra-update.sh
 
 [Install]

--- a/firmware/ra-update@ttyLP1.service.d/ConditionFirmware.conf
+++ b/firmware/ra-update@ttyLP1.service.d/ConditionFirmware.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionFirmware=|device-tree-compatible(chargebyte,imx93-charge-control-v)

--- a/firmware/ra-update@ttyLP1.service.d/Environment.conf
+++ b/firmware/ra-update@ttyLP1.service.d/Environment.conf
@@ -1,0 +1,4 @@
+[Service]
+Environment="SAFETY_MCU_GPIOCHIP=/dev/gpiochip1"
+Environment="SAFETY_MCU_RESET_GPIO=nSAFETY2_RESET_INT"
+Environment="SAFETY_MCU_MD_GPIO=SAFETY2_BOOTMODE_SET"

--- a/firmware/ra-update@ttyLP2.service.d/ConditionFirmware.conf
+++ b/firmware/ra-update@ttyLP2.service.d/ConditionFirmware.conf
@@ -1,0 +1,3 @@
+[Unit]
+ConditionFirmware=|device-tree-compatible(chargebyte,imx93-charge-som)
+ConditionFirmware=|device-tree-compatible(chargebyte,imx93-charge-control-y)

--- a/src/gpio-defaults.h
+++ b/src/gpio-defaults.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2026 chargebyte GmbH
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+/* the default gpiochip device to use */
+#define DEFAULT_RA_GPIOCHIP "/dev/gpiochip2"
+
+/* the default gpio name of the MCU reset pin */
+#define DEFAULT_RA_GPIO_RESET_PIN "nSAFETY_RESET_INT"
+
+/* the default gpio name of the gpio to toggle the MCU boot mode */
+#define DEFAULT_RA_GPIO_MD_PIN "SAFETY_BOOTMODE_SET"
+
+/* name of environment variable to override compiled-in DEFAULT_RA_GPIOCHIP */
+#define GETENV_GPIOCHIP_KEY "SAFETY_MCU_GPIOCHIP"
+
+/* name of environment variable to override compiled-in DEFAULT_RA_GPIO_RESET_PIN */
+#define GETENV_RESET_PIN_KEY "SAFETY_MCU_RESET_GPIO"
+
+/* name of environment variable to override compiled-in DEFAULT_RA_GPIO_MD_PIN */
+#define GETENV_MD_PIN_KEY "SAFETY_MCU_MD_GPIO"

--- a/src/ra-raw.c
+++ b/src/ra-raw.c
@@ -48,6 +48,7 @@
 #include <version.h>
 #include "ra_gpio.h"
 #include "stringify.h"
+#include "gpio-defaults.h"
 #include "uart-defaults.h"
 
 /* fallback if not set by build system */
@@ -248,6 +249,9 @@ int main(int argc, char *argv[])
     struct pollfd poll_fds[2]; /* stdin at [0], UART fd at [1] */
     int fds = 2;
     char *env_uart_device = NULL;
+    char *env_gpiochip = NULL;
+    char *env_reset_gpioname = NULL;
+    char *env_md_gpioname = NULL;
     struct uart_ctx uart = { .fd = -1 };
     struct safety_controller ctx = {};
     enum cb_uart_com com;
@@ -259,13 +263,25 @@ int main(int argc, char *argv[])
     int rc = EXIT_FAILURE;
     int rv;
 
-    /* check whether environment variable SAFETY_MCU_UART is set and use it
+    /* check whether any of the environment variables SAFETY_MCU_... is set and use it
      * as default; so the resulting order is:
      * compiled-in default -> can be overridden by environment -> can be overridden by cmdline
      */
     env_uart_device = getenv(GETENV_UART_KEY);
     if (env_uart_device)
         uart_device = env_uart_device;
+
+    env_gpiochip = getenv(GETENV_GPIOCHIP_KEY);
+    if (env_gpiochip)
+        gpiochip = env_gpiochip;
+
+    env_reset_gpioname = getenv(GETENV_RESET_PIN_KEY);
+    if (env_reset_gpioname)
+        reset_gpioname = env_reset_gpioname;
+
+    env_md_gpioname = getenv(GETENV_MD_PIN_KEY);
+    if (env_md_gpioname)
+        md_gpioname = env_md_gpioname;
 
     /* handle command line options */
     parse_cli(argc, argv);

--- a/src/ra-update.c
+++ b/src/ra-update.c
@@ -57,6 +57,7 @@
 #include "fw_file.h"
 #include "ra_gpio.h"
 #include "stringify.h"
+#include "gpio-defaults.h"
 #include "uart-defaults.h"
 
 /* fallback if not set by build system */
@@ -424,6 +425,9 @@ int main(int argc, char *argv[])
 {
     struct version_app_infoblock version_info;
     char *env_uart_device = NULL;
+    char *env_gpiochip = NULL;
+    char *env_reset_gpioname = NULL;
+    char *env_md_gpioname = NULL;
     struct uart_ctx uart = { .fd = -1 };
     struct gpio_ctx *gpio = NULL;
     uint8_t *fw_content = NULL;
@@ -433,13 +437,25 @@ int main(int argc, char *argv[])
     int rc = EXIT_FAILURE;
     int rv;
 
-    /* check whether environment variable SAFETY_MCU_UART is set and use it
+    /* check whether any of the environment variables SAFETY_MCU_... is set and use it
      * as default; so the resulting order is:
      * compiled-in default -> can be overridden by environment -> can be overridden by cmdline
      */
     env_uart_device = getenv(GETENV_UART_KEY);
     if (env_uart_device)
         uart_device = env_uart_device;
+
+    env_gpiochip = getenv(GETENV_GPIOCHIP_KEY);
+    if (env_gpiochip)
+        gpiochip = env_gpiochip;
+
+    env_reset_gpioname = getenv(GETENV_RESET_PIN_KEY);
+    if (env_reset_gpioname)
+        reset_gpioname = env_reset_gpioname;
+
+    env_md_gpioname = getenv(GETENV_MD_PIN_KEY);
+    if (env_md_gpioname)
+        md_gpioname = env_md_gpioname;
 
     /* handle command line options */
     parse_cli(argc, argv);

--- a/src/ra_gpio.h
+++ b/src/ra_gpio.h
@@ -6,15 +6,6 @@
 
 #include <gpiod.h>
 
-/* the default gpiochip device to use */
-#define DEFAULT_RA_GPIOCHIP "/dev/gpiochip2"
-
-/* the default gpio name of the MCU reset pin */
-#define DEFAULT_RA_GPIO_RESET_PIN "nSAFETY_RESET_INT"
-
-/* the default gpio name of the gpio to toogle the MCU boot mode */
-#define DEFAULT_RA_GPIO_MD_PIN "SAFETY_BOOTMODE_SET"
-
 /* forward declaration */
 struct gpio_ctx;
 


### PR DESCRIPTION
With this PR, support for multiple instances of the safety controller on one platform is improved.
The main goal is to check on several UARTs whether a firmware update is required.

A corresponding small change in our meta-chargebyte-distro layer will be necessary, to enable
all required instances on our products.
